### PR TITLE
fix: prioritize visible map labels

### DIFF
--- a/src/app/api/v1/conflicts/[id]/map/data/route.ts
+++ b/src/app/api/v1/conflicts/[id]/map/data/route.ts
@@ -84,7 +84,7 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
       const props = f.properties as Props;
       return {
         id: f.id, actor: f.actor, priority: f.priority, category: f.category, type: f.type,
-        status: f.status,
+        status: f.status, timestamp: f.timestamp?.toISOString() ?? '',
         position: geo.position, name: props.name, description: props.description,
       };
     });
@@ -96,7 +96,7 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
       const props = f.properties as Props;
       return {
         id: f.id, actor: f.actor, priority: f.priority, category: f.category, type: f.type,
-        coordinates: geo.coordinates, name: props.name, color: props.color,
+        timestamp: f.timestamp?.toISOString() ?? '', coordinates: geo.coordinates, name: props.name, color: props.color,
       };
     });
 

--- a/src/data/map-data.ts
+++ b/src/data/map-data.ts
@@ -59,6 +59,7 @@ export type Asset = {
   category:    Extract<MarkerCategory, 'INSTALLATION'>;
   type:        Extract<InstallationType, 'CARRIER' | 'AIR_BASE' | 'NAVAL_BASE' | 'ARMY_BASE'>;
   status:      InstallationStatus;
+  timestamp?:  string;
   name:        string;
   position:    [number, number];
   description?: string;
@@ -70,6 +71,7 @@ export type ThreatZone = {
   priority:    Priority;
   category:    Extract<MarkerCategory, 'ZONE'>;
   type:        ZoneType;
+  timestamp?:  string;
   name:        string;
   coordinates: [number, number][];
   color:       [number, number, number, number];

--- a/src/features/map/components/use-map-page.ts
+++ b/src/features/map/components/use-map-page.ts
@@ -4,8 +4,6 @@ import { useCallback, useMemo, useState } from 'react';
 
 import type { MapViewState, PickingInfo } from '@deck.gl/core';
 
-import { track } from '@/shared/lib/analytics';
-
 import type { OverlayVisibility } from '@/features/map/components/MapVisibilityMenu';
 import type { SelectedItem } from '@/features/map/components/types';
 import { useMapFilters } from '@/features/map/hooks/use-map-filters';
@@ -21,6 +19,8 @@ import {
   setViewState    as setViewStateAction,
   toggleSidebar   as toggleSidebarAction,
 } from '@/features/map/state/map-slice';
+
+import { track } from '@/shared/lib/analytics';
 
 import type { Asset, MissileTrack, StrikeArc, Target, ThreatZone } from '@/data/map-data';
 
@@ -52,6 +52,8 @@ export function useMapPage({ isMobile }: { isMobile: boolean }) {
     filtered:    f.filtered,
     actorMeta:   f.actorMeta,
     activeStory,
+    selectedItem,
+    viewState,
     isSatellite: mapStyle === 'satellite',
     isMobile,
   });

--- a/src/features/map/hooks/use-map-filters.ts
+++ b/src/features/map/hooks/use-map-filters.ts
@@ -39,7 +39,7 @@ export const DATASET_LABEL: Record<DatasetName, string> = {
 function buildFingerprint(rawData: DataArrays): string {
   let minTs = Number.POSITIVE_INFINITY;
   let maxTs = Number.NEGATIVE_INFINITY;
-  for (const entry of [...rawData.strikes, ...rawData.missiles, ...rawData.targets]) {
+  for (const entry of [...rawData.strikes, ...rawData.missiles, ...rawData.targets, ...rawData.assets, ...rawData.zones]) {
     if (!entry.timestamp) continue;
     const ts = new Date(entry.timestamp).getTime();
     if (!Number.isFinite(ts)) continue;

--- a/src/features/map/hooks/use-map-layers.ts
+++ b/src/features/map/hooks/use-map-layers.ts
@@ -3,7 +3,11 @@
 import { useMemo } from 'react';
 
 import { HeatmapLayer } from '@deck.gl/aggregation-layers';
+import type { Layer, MapViewState } from '@deck.gl/core';
 import { ArcLayer, PolygonLayer,ScatterplotLayer, TextLayer } from '@deck.gl/layers';
+
+import type { SelectedItem } from '@/features/map/components/types';
+import { selectVisibleLabels } from '@/features/map/lib/label-visibility';
 
 import type { Asset, HeatPoint,MissileTrack, StrikeArc, Target, ThreatZone } from '@/data/map-data';
 import type { ActorMeta } from '@/data/map-tokens';
@@ -23,6 +27,8 @@ type Props = {
   filtered:    FilteredData;
   actorMeta:   Record<string, ActorMeta>;
   activeStory: MapStory | null;
+  selectedItem: SelectedItem | null;
+  viewState: MapViewState;
   isSatellite: boolean;
   isMobile?:   boolean;
 };
@@ -62,8 +68,16 @@ function statusFill(status: Target['status'] | Asset['status']): [number, number
 
 // Hook
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function useMapLayers({ filtered, actorMeta, activeStory, isSatellite, isMobile = false }: Props): any[] {
+ 
+export function useMapLayers({
+  filtered,
+  actorMeta,
+  activeStory,
+  selectedItem,
+  viewState,
+  isSatellite,
+  isMobile = false,
+}: Props): Layer[] {
   return useMemo(() => {
     const alpha    = activeAlpha(isSatellite);
     const dimActive = activeStory !== null;
@@ -75,6 +89,13 @@ export function useMapLayers({ filtered, actorMeta, activeStory, isSatellite, is
     const labelWeight  = isSatellite ? 700 : 400;
     const labelBg: RGBA = isSatellite ? [10, 14, 22, 230] : [28, 33, 39, 200];
     const strokeWidth  = isSatellite ? 2 : 1;
+    const visibleLabels = selectVisibleLabels(
+      filtered.targets,
+      filtered.assets,
+      viewState,
+      selectedItem,
+      activeStory,
+    );
 
     // Heat map
     const heatLayer = filtered.heat.length > 0 && new HeatmapLayer<HeatPoint>({
@@ -203,9 +224,9 @@ export function useMapLayers({ filtered, actorMeta, activeStory, isSatellite, is
     });
 
     // Target labels
-    const targetLabels = !isMobile && filtered.targets.length > 0 && new TextLayer<Target>({
+    const targetLabels = !isMobile && visibleLabels.targets.length > 0 && new TextLayer<Target>({
       id: 'target-labels',
-      data: filtered.targets,
+      data: visibleLabels.targets,
       getPosition:       (d: Target): [number, number] => d.position,
       getText:           (d: Target): string => d.name,
       getSize:           labelSize,
@@ -222,9 +243,9 @@ export function useMapLayers({ filtered, actorMeta, activeStory, isSatellite, is
     });
 
     // Asset labels
-    const assetLabels = !isMobile && filtered.assets.length > 0 && new TextLayer<Asset>({
+    const assetLabels = !isMobile && visibleLabels.assets.length > 0 && new TextLayer<Asset>({
       id: 'asset-labels',
-      data: filtered.assets,
+      data: visibleLabels.assets,
       getPosition:       (d: Asset): [number, number] => d.position,
       getText:           (d: Asset): string => d.name,
       getSize:           isSatellite ? 11 : 10,
@@ -243,8 +264,10 @@ export function useMapLayers({ filtered, actorMeta, activeStory, isSatellite, is
       updateTriggers:    { getColor: [isSatellite], getBackgroundColor: [isSatellite] },
     });
 
-    return [heatLayer, zoneLayer, strikeLayer, missileLayer, targetLayer, assetLayer, targetLabels, assetLabels].filter(Boolean);
-  }, [filtered, actorMeta, activeStory, isSatellite, isMobile]);
+    const layers = [heatLayer, zoneLayer, strikeLayer, missileLayer, targetLayer, assetLayer, targetLabels, assetLabels].filter(Boolean);
+
+    return layers as Layer[];
+  }, [filtered, actorMeta, activeStory, selectedItem, viewState, isSatellite, isMobile]);
 }
 
 // Re-export so tooltip handler can share STATUS_META without another import

--- a/src/features/map/lib/label-visibility.ts
+++ b/src/features/map/lib/label-visibility.ts
@@ -1,0 +1,150 @@
+import type { MapViewState } from '@deck.gl/core';
+
+import type { SelectedItem } from '@/features/map/components/types';
+
+import type { Asset, Target } from '@/data/map-data';
+import type { MapStory } from '@/types/domain';
+
+type LabelCandidate = {
+  id: string;
+  kind: 'target' | 'asset';
+  point: Target | Asset;
+  position: [number, number];
+  score: number;
+  pinned: boolean;
+};
+
+type LabelSelection = {
+  targets: Target[];
+  assets: Asset[];
+};
+
+const PRIORITY_SCORE = { P1: 130, P2: 80, P3: 30 } as const;
+const STATUS_SCORE = { ACTIVE: 10, DEGRADED: 40, STRUCK: 85, DAMAGED: 110, DESTROYED: 140 } as const;
+const TYPE_SCORE = { CARRIER: 150, NUCLEAR_SITE: 130, AIR_BASE: 110, NAVAL_BASE: 105, COMMAND: 80, ARMY_BASE: 55, INFRASTRUCTURE: 15 } as const;
+
+function labelBudget(zoom: number) {
+  if (zoom < 4.5) return { maxTotal: 10, maxPerCell: 1, cellLng: 7, cellLat: 4 };
+  if (zoom < 5.5) return { maxTotal: 16, maxPerCell: 1, cellLng: 4.5, cellLat: 2.8 };
+  if (zoom < 6.5) return { maxTotal: 24, maxPerCell: 2, cellLng: 2.4, cellLat: 1.6 };
+  if (zoom < 7.5) return { maxTotal: 34, maxPerCell: 2, cellLng: 1.2, cellLat: 0.9 };
+  return { maxTotal: 48, maxPerCell: 3, cellLng: 0.7, cellLat: 0.55 };
+}
+
+function recencyScore(timestamp?: string) {
+  if (!timestamp) return -30;
+  const age = Date.now() - new Date(timestamp).getTime();
+
+  if (!Number.isFinite(age) || age < 0) return 0;
+  if (age <= 12 * 60 * 60 * 1000) return 140;
+  if (age <= 24 * 60 * 60 * 1000) return 110;
+  if (age <= 3 * 24 * 60 * 60 * 1000) return 70;
+  if (age <= 7 * 24 * 60 * 60 * 1000) return 35;
+
+  return 0;
+}
+
+function centerBias(position: [number, number], viewState: MapViewState) {
+  const lngSpan = 360 / 2 ** Math.max(viewState.zoom - 1, 0);
+  const latSpan = 180 / 2 ** Math.max(viewState.zoom - 1, 0);
+  const lngDist = Math.abs(position[0] - viewState.longitude) / Math.max(lngSpan, 0.0001);
+  const latDist = Math.abs(position[1] - viewState.latitude) / Math.max(latSpan, 0.0001);
+
+  return Math.max(0, 60 - (lngDist + latDist) * 90);
+}
+
+function isInViewport(position: [number, number], viewState: MapViewState) {
+  const lngSpan = 360 / 2 ** Math.max(viewState.zoom - 1, 0);
+  const latSpan = 180 / 2 ** Math.max(viewState.zoom - 1, 0);
+  const lngDist = Math.abs(position[0] - viewState.longitude);
+  const latDist = Math.abs(position[1] - viewState.latitude);
+
+  return lngDist <= lngSpan * 0.7 && latDist <= latSpan * 0.7;
+}
+
+function isSelected(point: Target | Asset, selectedItem: SelectedItem | null) {
+  return selectedItem?.type === 'target' || selectedItem?.type === 'asset'
+    ? selectedItem.data.id === point.id
+    : false;
+}
+
+function scoreTarget(target: Target, viewState: MapViewState, selectedItem: SelectedItem | null, activeStory: MapStory | null) {
+  return (PRIORITY_SCORE[target.priority] ?? 0)
+    + (STATUS_SCORE[target.status] ?? 0)
+    + (TYPE_SCORE[target.type] ?? 0)
+    + recencyScore(target.timestamp)
+    + centerBias(target.position, viewState)
+    + (activeStory?.highlightTargetIds.includes(target.id) ? 320 : activeStory ? -60 : 0)
+    + (isSelected(target, selectedItem) ? 1000 : 0);
+}
+
+function scoreAsset(asset: Asset, viewState: MapViewState, selectedItem: SelectedItem | null, activeStory: MapStory | null) {
+  return (PRIORITY_SCORE[asset.priority] ?? 0)
+    + (STATUS_SCORE[asset.status] ?? 0)
+    + (TYPE_SCORE[asset.type] ?? 0)
+    + recencyScore(asset.timestamp)
+    + centerBias(asset.position, viewState)
+    + (activeStory?.highlightAssetIds.includes(asset.id) ? 320 : activeStory ? -70 : 0)
+    + (!asset.timestamp && asset.priority === 'P3' ? -45 : 0)
+    + (isSelected(asset, selectedItem) ? 1000 : 0);
+}
+
+function toCellKey(position: [number, number], zoom: number) {
+  const budget = labelBudget(zoom);
+  const lng = Math.floor((position[0] + 180) / budget.cellLng);
+  const lat = Math.floor((position[1] + 90) / budget.cellLat);
+
+  return `${lng}:${lat}`;
+}
+
+export function selectVisibleLabels(
+  targets: Target[],
+  assets: Asset[],
+  viewState: MapViewState,
+  selectedItem: SelectedItem | null,
+  activeStory: MapStory | null,
+): LabelSelection {
+  const budget = labelBudget(viewState.zoom);
+  const candidates: LabelCandidate[] = [
+    ...targets.map((target) => ({
+      id: target.id,
+      kind: 'target' as const,
+      point: target,
+      position: target.position,
+      score: scoreTarget(target, viewState, selectedItem, activeStory),
+      pinned: isSelected(target, selectedItem) || !!activeStory?.highlightTargetIds.includes(target.id),
+    })),
+    ...assets.map((asset) => ({
+      id: asset.id,
+      kind: 'asset' as const,
+      point: asset,
+      position: asset.position,
+      score: scoreAsset(asset, viewState, selectedItem, activeStory),
+      pinned: isSelected(asset, selectedItem) || !!activeStory?.highlightAssetIds.includes(asset.id),
+    })),
+  ]
+    .filter((candidate) => isSelected(candidate.point, selectedItem) || isInViewport(candidate.position, viewState))
+    .sort((a, b) => b.score - a.score);
+
+  const picked = new Set<string>();
+  const cellCounts = new Map<string, number>();
+  const selected: LabelCandidate[] = [];
+
+  for (const candidate of candidates) {
+    const cellKey = toCellKey(candidate.position, viewState.zoom);
+    const cellCount = cellCounts.get(cellKey) ?? 0;
+    const canBypassCell = candidate.pinned && selected.length < Math.min(12, budget.maxTotal);
+
+    if (!canBypassCell && (selected.length >= budget.maxTotal || cellCount >= budget.maxPerCell)) continue;
+    if (picked.has(candidate.id)) continue;
+
+    picked.add(candidate.id);
+    selected.push(candidate);
+    cellCounts.set(cellKey, cellCount + 1);
+  }
+
+  return {
+    targets: selected.filter((item): item is LabelCandidate & { point: Target; kind: 'target' } => item.kind === 'target').map((item) => item.point),
+    assets: selected.filter((item): item is LabelCandidate & { point: Asset; kind: 'asset' } => item.kind === 'asset').map((item) => item.point),
+  };
+}

--- a/src/features/map/lib/map-filter-engine.ts
+++ b/src/features/map/lib/map-filter-engine.ts
@@ -109,12 +109,12 @@ export function extractInitialState(data: DataArrays): FilterState {
   return { datasets, types, actors, statuses, priorities, heat: true, timeRange: null };
 }
 
-/** Derive min/max timestamps from timestamped data only (strikes, missiles, targets).
+/** Derive min/max timestamps from timestamped data only.
  *  Max is always at least "now" so the timeline extends to the current time. */
 export function extractTimeExtent(data: DataArrays): [number, number] {
   let min = Infinity;
   let max = -Infinity;
-  for (const dk of ['strikes', 'missiles', 'targets'] as const) {
+  for (const dk of ['strikes', 'missiles', 'targets', 'assets', 'zones'] as const) {
     for (const d of datasetItems(data, dk)) {
       if (!d.timestamp) continue;
       const t = new Date(d.timestamp).getTime();
@@ -144,7 +144,7 @@ export function applyFilters(
 
   const inTime = (item: DataItem): boolean => {
     if (!state.timeRange) return true;
-    if (!item.timestamp) return true; // static items (assets, zones) always visible
+    if (!item.timestamp) return true;
     const t = new Date(item.timestamp).getTime();
     return t >= state.timeRange[0] && t <= state.timeRange[1];
   };


### PR DESCRIPTION
## Summary
- add a label visibility engine that budgets target and asset labels by zoom level, viewport, recency, and priority
- keep selected and story-highlighted labels pinned while reducing map clutter at lower zoom levels
- include asset and zone timestamps in the map data flow so timeline and label scoring use the full dataset