### PR TITLE
docs: soften Pharos duplicate-check guidance

### DIFF
--- a/agent/AGENTS.md
+++ b/agent/AGENTS.md
@@ -36,7 +36,12 @@ A bad run:
 
 ## Operational rule
 
-If you cannot explain in one sentence why something is a new event instead of an update, it is probably an update.
+Use recent events as a collision check, not as a cap on valid event creation.
+
+Update when new detail clearly belongs to the same incident already in the system.
+Create when the development is distinct in wave, location, actor action, official decision, or consequence.
+
+If you cannot explain in one sentence why something is a new event instead of an update, stop and compare it against recent events before writing.
 
 ## Story rule
 

--- a/agent/BOOTSTRAP_MESSAGE.md
+++ b/agent/BOOTSTRAP_MESSAGE.md
@@ -9,8 +9,10 @@ On every run:
 3. Use scripts under workspace/pharos-fulfillment/YYYY-MM-DD/
 4. Use Europe/Stockholm for day assignment unless the conflict timezone says otherwise
 5. Default to NOOP if nothing materially new happened
-6. Prefer update over create
-7. Only create stories that are truly map-worthy
-8. Verify consumer/workspace state before claiming success
+6. Use recent events as a collision check, not as a cap on valid event creation
+7. Update only when new detail clearly belongs to the same incident already in the system
+8. Create when the development is distinct in wave, location, actor action, official decision, or consequence
+9. Only create stories that are truly map-worthy
+10. Verify consumer/workspace state before claiming success
 
 Auth and base URL should be handled by the shared client and environment, not hardcoded into the prompt.

--- a/agent/HEARTBEAT.md
+++ b/agent/HEARTBEAT.md
@@ -14,8 +14,10 @@
    - SIGNAL_ONLY
 6. If nothing materially new happened, do nothing
 7. If writing:
+   - use recentEvents as a collision check, not as a limit on valid new events
+   - update only when the candidate clearly belongs to the same incident already in the system
+   - create when the development is distinct in wave, location, actor action, official decision, or consequence
    - use scripts only
-   - prefer update over create
    - create stories only if truly map-worthy
 8. Verify consumer/workspace state before success
 

--- a/src/app/api/v1/admin/[conflictId]/workspace/route.ts
+++ b/src/app/api/v1/admin/[conflictId]/workspace/route.ts
@@ -492,7 +492,7 @@ export async function GET(
     recentEvents: {
       windowDays: RECENT_WINDOW_DAYS,
       count: recentEvents.length,
-      note: 'Review before creating new events. If a candidate overlaps in incident, time, location, or actor with an existing item, prefer UPDATE over CREATE.',
+      note: 'Review before creating new events. Use this as a collision check, not a cap on valid event creation. Same incident with new detail usually means UPDATE; a distinct wave, location, actor action, decision, or consequence usually means CREATE.',
       items: recentEvents,
     },
     maintenance: {


### PR DESCRIPTION
## Summary
- reframe recent-event review as a collision check instead of a cap on valid new event creation
- update the Pharos agent mirrors and bootstrap prompt so busy conflict days still produce distinct events when the development is clearly separate
- align the `/workspace` recent-events note with the new create-vs-update guidance