### PR TITLE
fix: validate datasets param in map/data route and correct API docs

### DIFF
--- a/public/openapi.json
+++ b/public/openapi.json
@@ -423,8 +423,8 @@
           {
             "name": "datasets",
             "in": "query",
-            "schema": { "type": "string" },
-            "description": "Comma-separated dataset names to include (e.g. `strikes,missiles,targets`)"
+            "schema": { "type": "string", "enum": ["STRIKE_ARC", "MISSILE_TRACK", "TARGET", "ASSET", "THREAT_ZONE", "HEAT_POINT"] },
+            "description": "Comma-separated MapFeatureType values to filter by (e.g. `STRIKE_ARC,TARGET`)"
           }
         ],
         "responses": {

--- a/src/app/api/v1/conflicts/[id]/map/data/route.ts
+++ b/src/app/api/v1/conflicts/[id]/map/data/route.ts
@@ -2,16 +2,26 @@ import { NextRequest } from 'next/server';
 
 import { err, ok, parseQueryArray } from '@/server/lib/api-utils';
 import { prisma } from '@/server/lib/db';
+import { MapFeatureType } from '@/generated/prisma/enums';
+
+const VALID_FEATURE_TYPES = Object.values(MapFeatureType) as string[];
 
 export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
   const datasets = parseQueryArray(req.nextUrl.searchParams.get('datasets'));
 
+  if (datasets.length > 0) {
+    const invalid = datasets.filter(d => !VALID_FEATURE_TYPES.includes(d));
+    if (invalid.length > 0) {
+      return err('VALIDATION', `Invalid dataset value(s): ${invalid.join(', ')}. Valid values: ${VALID_FEATURE_TYPES.join(', ')}`, 400);
+    }
+  }
+
   const [features, actors] = await Promise.all([
     prisma.mapFeature.findMany({
       where: {
         conflictId: id,
-        ...(datasets.length > 0 ? { featureType: { in: datasets as never[] } } : {}),
+        ...(datasets.length > 0 ? { featureType: { in: datasets as MapFeatureType[] } } : {}),
       },
       orderBy: { timestamp: 'asc' },
       select: {


### PR DESCRIPTION
## Summary

- The `GET /conflicts/{id}/map/data?datasets=` endpoint passed raw query values straight to Prisma without validating against the `MapFeatureType` enum, causing a **500** on production when consumer-friendly aliases like `strikes` were used instead of the actual enum value `STRIKE_ARC`
- Added early validation that returns a clear **400** listing valid values
- Updated `openapi.json` to document the correct enum values instead of the wrong aliases

## Changes (2 files, +13 -3)

- **`src/app/api/v1/conflicts/[id]/map/data/route.ts`** — validate `datasets` values against `MapFeatureType` enum before querying; return `400` with valid values on mismatch; replace unsafe `as never[]` cast with `as MapFeatureType[]`
- **`public/openapi.json`** — fix `datasets` param description and schema to use actual enum values (`STRIKE_ARC`, `MISSILE_TRACK`, `TARGET`, `ASSET`, `THREAT_ZONE`, `HEAT_POINT`)

## Repro

```
# Before (500):
curl "https://www.conflicts.app/api/v1/conflicts/iran-2026/map/data?datasets=strikes"

# After (400 with helpful message):
# → { ok: false, error: { code: "VALIDATION", message: "Invalid dataset value(s): strikes. Valid values: STRIKE_ARC, ..." } }

# Correct usage (200):
curl "https://www.conflicts.app/api/v1/conflicts/iran-2026/map/data?datasets=STRIKE_ARC,TARGET"
```