### PR TITLE
fix: map crash on features with null or invalid status

### DIFF
--- a/src/app/api/v1/conflicts/[id]/map/data/route.ts
+++ b/src/app/api/v1/conflicts/[id]/map/data/route.ts
@@ -52,6 +52,17 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
   type Geo = Record<string, unknown>;
   type Props = Record<string, unknown>;
 
+  const KINETIC_DEFAULT = 'COMPLETE';
+  const INSTALLATION_DEFAULT = 'ACTIVE';
+
+  /** Normalize status: uppercase + default for null/unknown. */
+  function normStatus(raw: string | null, featureType: string): string {
+    if (!raw) return featureType === 'STRIKE_ARC' || featureType === 'MISSILE_TRACK' ? KINETIC_DEFAULT : INSTALLATION_DEFAULT;
+    const upper = raw.toUpperCase();
+    const valid = ['COMPLETE', 'INTERCEPTED', 'IMPACTED', 'ACTIVE', 'DEGRADED', 'STRUCK', 'DAMAGED', 'DESTROYED'];
+    return valid.includes(upper) ? upper : (featureType === 'STRIKE_ARC' || featureType === 'MISSILE_TRACK' ? KINETIC_DEFAULT : INSTALLATION_DEFAULT);
+  }
+
   const strikes = features
     .filter(f => f.featureType === 'STRIKE_ARC')
     .map(f => {
@@ -59,7 +70,7 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
         const props = f.properties as Props;
         return {
           id: f.id, sourceEventId: f.sourceEventId, actor: f.actor, priority: f.priority, category: f.category, type: f.type,
-          status: f.status, timestamp: f.timestamp?.toISOString() ?? '',
+          status: normStatus(f.status, f.featureType), timestamp: f.timestamp?.toISOString() ?? '',
           from: geo.from, to: geo.to, label: props.label, severity: props.severity,
         };
     });
@@ -71,7 +82,7 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
         const props = f.properties as Props;
         return {
           id: f.id, sourceEventId: f.sourceEventId, actor: f.actor, priority: f.priority, category: f.category, type: f.type,
-          status: f.status, timestamp: f.timestamp?.toISOString() ?? '',
+          status: normStatus(f.status, f.featureType), timestamp: f.timestamp?.toISOString() ?? '',
           from: geo.from, to: geo.to, label: props.label, severity: props.severity,
         };
     });
@@ -83,7 +94,7 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
         const props = f.properties as Props;
         return {
           id: f.id, sourceEventId: f.sourceEventId, actor: f.actor, priority: f.priority, category: f.category, type: f.type,
-          status: f.status, timestamp: f.timestamp?.toISOString() ?? '',
+          status: normStatus(f.status, f.featureType), timestamp: f.timestamp?.toISOString() ?? '',
           position: geo.position, name: props.name, description: props.description,
         };
     });
@@ -95,7 +106,7 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
         const props = f.properties as Props;
         return {
           id: f.id, sourceEventId: f.sourceEventId, actor: f.actor, priority: f.priority, category: f.category, type: f.type,
-          status: f.status, timestamp: f.timestamp?.toISOString() ?? '',
+          status: normStatus(f.status, f.featureType), timestamp: f.timestamp?.toISOString() ?? '',
           position: geo.position, name: props.name, description: props.description,
         };
     });

--- a/src/features/map/components/MapDetailContent.tsx
+++ b/src/features/map/components/MapDetailContent.tsx
@@ -8,8 +8,16 @@ import { fmtDate, fmtTimeZ } from '@/shared/lib/format';
 
 import type { Asset, MissileTrack, StrikeArc, Target, ThreatZone } from '@/data/map-data';
 import type { ActorMeta } from '@/data/map-tokens';
-import { CATEGORY_LABEL, STATUS_META } from '@/data/map-tokens';
+import { CATEGORY_LABEL, STATUS_META, type MarkerStatus } from '@/data/map-tokens';
 import type { MapStory } from '@/types/domain';
+
+const FALLBACK_STATUS = { label: 'Unknown', cssVar: 'var(--t4)' } as const;
+
+/** Safe STATUS_META lookup — returns fallback for null/unknown status values. */
+function statusMeta(status: string | null | undefined) {
+  if (!status) return FALLBACK_STATUS;
+  return STATUS_META[status as MarkerStatus] ?? FALLBACK_STATUS;
+}
 
 import { StoryIcon } from './StoryIcon';
 import type { SelectedItem } from './types';
@@ -132,7 +140,7 @@ export function StrikeContent({ d, onSelectItem, onActivateStory }: {
   const { rawData, stories, actorMeta } = useMapCrossRefData();
   const relatedTarget  = rawData ? targetForStrike(d, rawData.targets) : null;
   const relatedStories = storiesFor([d.id], 'highlightStrikeIds', stories);
-  const statusMeta     = STATUS_META[d.status];
+  const sMeta          = statusMeta(d.status);
 
   return (
     <>
@@ -140,7 +148,7 @@ export function StrikeContent({ d, onSelectItem, onActivateStory }: {
       <div className="flex gap-1 flex-wrap" style={{ marginBottom: 14 }}>
         <Badge label={d.type.replace('_', ' ')} color={am(d.actor, actorMeta).cssVar} />
         <Badge label={d.severity}               color={d.severity === 'CRITICAL' ? 'var(--danger)' : 'var(--warning)'} />
-        <Badge label={statusMeta.label}          color={statusMeta.cssVar} />
+        <Badge label={sMeta.label}               color={sMeta.cssVar} />
       </div>
       {d.timestamp && <Row label="TIME" value={`${fmtDate(d.timestamp)} · ${fmtTimeZ(d.timestamp)}`} color="var(--blue-l)" />}
       <Row label="ORIGIN"        value={`[${d.from[1].toFixed(2)}°N, ${d.from[0].toFixed(2)}°E]`} />
@@ -152,7 +160,7 @@ export function StrikeContent({ d, onSelectItem, onActivateStory }: {
           <Button variant="ghost" onClick={() => onSelectItem({ type: 'target', data: relatedTarget })}
             className="flex items-center gap-2 w-full text-left hover:border-[var(--bd)] transition-colors" style={{ background: 'var(--bg-1)', border: '1px solid var(--bd-s)', borderRadius: 2, padding: '8px 10px' }}
           >
-            <span className="dot" style={{ background: STATUS_META[relatedTarget.status].cssVar }} />
+            <span className="dot" style={{ background: statusMeta(relatedTarget.status).cssVar }} />
             <div className="flex-1 min-w-0">
               <p style={{ fontSize: 11, color: 'var(--t2)', fontWeight: 600 }}>{relatedTarget.name}</p>
               <p className="mono" style={{ fontSize: 9, color: 'var(--t4)', marginTop: 1 }}>
@@ -209,7 +217,7 @@ export function TargetContent({ d, onSelectItem, onActivateStory }: {
   onActivateStory: (s: MapStory) => void;
 }) {
   const { rawData, stories, actorMeta } = useMapCrossRefData();
-  const statusMeta     = STATUS_META[d.status];
+  const tStatusMeta    = statusMeta(d.status);
   const m              = am(d.actor, actorMeta);
   const incomingStrikes = rawData ? strikesForTarget(d, rawData.strikes) : [];
   const relatedStories = storiesFor([d.id], 'highlightTargetIds', stories);
@@ -219,7 +227,7 @@ export function TargetContent({ d, onSelectItem, onActivateStory }: {
       <HierarchyBreadcrumb actor={d.actor} category={d.category} type={d.type} actorMeta={actorMeta} />
       <div className="flex gap-1 flex-wrap" style={{ marginBottom: 12 }}>
         <Badge label={d.type.replace('_', ' ')} color={m.cssVar} />
-        <Badge label={d.status}                 color={statusMeta.cssVar} />
+        <Badge label={tStatusMeta.label}        color={tStatusMeta.cssVar} />
       </div>
       <p style={{ fontSize: 12, color: 'var(--t2)', lineHeight: 1.6, marginBottom: 12 }}>{d.description}</p>
       {d.timestamp && <Row label="TIME" value={`${fmtDate(d.timestamp)} · ${fmtTimeZ(d.timestamp)}`} color="var(--blue-l)" />}
@@ -269,7 +277,7 @@ export function AssetContent({ d, onActivateStory }: {
       <div className="flex gap-1 flex-wrap" style={{ marginBottom: 12 }}>
         <Badge label={m.label}                    color={m.cssVar} />
         <Badge label={d.type.replace('_', ' ')}   color="var(--t3)" />
-        <Badge label={STATUS_META[d.status].label} color={STATUS_META[d.status].cssVar} />
+        <Badge label={statusMeta(d.status).label} color={statusMeta(d.status).cssVar} />
         {d.type === 'CARRIER' && <Badge label="CARRIER STRIKE GROUP" color="var(--warning)" />}
       </div>
       {d.description && (

--- a/src/features/map/lib/map-tooltip.ts
+++ b/src/features/map/lib/map-tooltip.ts
@@ -10,7 +10,13 @@ import type { PickingInfo } from '@deck.gl/core';
 
 import type { Asset, MissileTrack, StrikeArc, Target, ThreatZone } from '@/data/map-data';
 import type { ActorMeta } from '@/data/map-tokens';
-import { STATUS_META } from '@/data/map-tokens';
+import { STATUS_META, type MarkerStatus } from '@/data/map-tokens';
+
+const FALLBACK_STATUS = { label: 'Unknown', cssVar: 'var(--t4)' } as const;
+function safeStatus(status: string | null | undefined) {
+  if (!status) return FALLBACK_STATUS;
+  return STATUS_META[status as MarkerStatus] ?? FALLBACK_STATUS;
+}
 
 // Inline timestamp formatter (no import to keep file pure .ts)
 
@@ -54,7 +60,7 @@ export function createBuildTooltip(am: Record<string, ActorMeta>) {
       <div style="font-weight:700;font-size:11px;color:var(--t1);margin-bottom:5px">${d.label}</div>
       ${ts ? `<div style="font-size:9px;color:var(--blue-l);font-weight:700;margin-bottom:5px;letter-spacing:0.04em">⏱ ${ts}</div>` : ''}
       <div style="margin-bottom:4px">${pill(m.label, m.cssVar)}${pill(d.type.replace('_', ' '), m.cssVar)}${pill(d.severity, sevColor)}</div>
-      <div style="font-size:10px;color:var(--t3)">STATUS: <span style="color:${STATUS_META[d.status].cssVar}">${STATUS_META[d.status].label}</span></div>
+      <div style="font-size:10px;color:var(--t3)">STATUS: <span style="color:${safeStatus(d.status).cssVar}">${safeStatus(d.status).label}</span></div>
     `;
   }
 
@@ -73,25 +79,25 @@ export function createBuildTooltip(am: Record<string, ActorMeta>) {
 
   function targetTooltip(d: Target): string {
     const m = meta(d.actor);
-    const statusMeta = STATUS_META[d.status];
+    const sm = safeStatus(d.status);
     const ts = fmtTs(d.timestamp);
     return `
       <div style="font-weight:700;font-size:12px;color:var(--t1);margin-bottom:5px">${d.name}</div>
       ${ts ? `<div style="font-size:9px;color:var(--blue-l);font-weight:700;margin-bottom:5px;letter-spacing:0.04em">⏱ ${ts}</div>` : ''}
-      <div style="margin-bottom:6px">${pill(m.label, m.cssVar)}${pill(d.type.replace('_', ' '), m.cssVar)}${pill(d.status, statusMeta.cssVar)}</div>
+      <div style="margin-bottom:6px">${pill(m.label, m.cssVar)}${pill(d.type.replace('_', ' '), m.cssVar)}${pill(sm.label, sm.cssVar)}</div>
       <div style="color:var(--t2);font-size:10px;line-height:1.5">${d.description}</div>
     `;
   }
 
   function assetTooltip(d: Asset): string {
     const m = meta(d.actor);
-    const statusMeta = STATUS_META[d.status];
+    const sm = safeStatus(d.status);
     const extra = d.type === 'CARRIER'
       ? `<div style="color:var(--warning);font-size:10px;margin-top:4px;font-weight:700">▶ CARRIER STRIKE GROUP</div>`
       : '';
     return `
       <div style="font-weight:700;font-size:12px;color:var(--t1);margin-bottom:6px">${d.name}</div>
-      <div style="margin-bottom:4px">${pill(m.label, m.cssVar)}${pill(d.type.replace('_', ' '), 'var(--t3)')}${pill(statusMeta.label, statusMeta.cssVar)}</div>
+      <div style="margin-bottom:4px">${pill(m.label, m.cssVar)}${pill(d.type.replace('_', ' '), 'var(--t3)')}${pill(sm.label, sm.cssVar)}</div>
       ${d.description ? `<div style="color:var(--t2);font-size:10px;line-height:1.5;margin-top:4px">${d.description}</div>` : ''}
       ${extra}
     `;


### PR DESCRIPTION
## Summary

- Fixes map "Reloading map..." crash when clicking or hovering over agent-created features with null or non-enum status values
- 16 strike arcs, 2 missiles, and 1 asset had `status: null`; 2 missiles had `status: 'confirmed'` (lowercase, not in enum)

## Root cause

`STATUS_META[d.status]` returns `undefined` when status is `null` or not in the enum. Accessing `.label` or `.cssVar` on `undefined` throws a TypeError, which `MapErrorBoundary` catches and shows "Reloading map...".

## Fix

**Consumer route** (`map/data/route.ts`): Added `normStatus()` — uppercases status, defaults null to `COMPLETE` for kinetic types or `ACTIVE` for installations.

**Frontend** (`MapDetailContent.tsx`, `map-tooltip.ts`): Safe `statusMeta()` / `safeStatus()` lookup functions with `FALLBACK_STATUS = { label: 'Unknown', cssVar: 'var(--t4)' }` — prevents crash even if the API returns unexpected values.