### PR TITLE
fix: constrain desktop signals layout width

### DIFF
--- a/src/features/signals/components/SignalsContent.tsx
+++ b/src/features/signals/components/SignalsContent.tsx
@@ -1,20 +1,19 @@
 'use client';
 
-import { useMemo,useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
-
-import { track } from '@/shared/lib/analytics';
-import { ResizableHandle,ResizablePanel, ResizablePanelGroup } from '@/components/ui/resizable';
+import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/components/ui/resizable';
 import { ScrollArea } from '@/components/ui/scroll-area';
 
 import { useXPosts } from '@/features/events/queries/x-posts';
 import { SectionHeader } from '@/features/signals/components/SectionHeader';
-import { type AccountType,SignalFilterRail, type Significance } from '@/features/signals/components/SignalFilterRail';
+import { type AccountType, SignalFilterRail, type Significance } from '@/features/signals/components/SignalFilterRail';
 import { ListDetailScreenSkeleton } from '@/shared/components/loading/screen-skeletons';
 import { XPostCard } from '@/shared/components/shared/XPostCard';
 
-import { dayLabel, dayShort,getDayFromTimestamp, getPostsForDay } from '@/shared/lib/day-filter';
+import { track } from '@/shared/lib/analytics';
+import { dayLabel, dayShort, getDayFromTimestamp, getPostsForDay } from '@/shared/lib/day-filter';
 import { timeAgo } from '@/shared/lib/format';
 import { useConflictDay } from '@/shared/hooks/use-conflict-day';
 import { useIsLandscapePhone } from '@/shared/hooks/use-is-landscape-phone';
@@ -199,22 +198,24 @@ export function SignalsContent() {
   }
 
   return (
-    <ResizablePanelGroup orientation="horizontal" defaultLayout={defaultLayout} onLayoutChanged={onLayoutChanged} className="flex-1 min-h-0 min-w-0">
-      <ResizablePanel id="filters" defaultSize="22%" minSize="15%" maxSize="35%" className="flex flex-col overflow-hidden min-w-[180px]">
-        {filterRail}
-      </ResizablePanel>
-      <ResizableHandle />
-      <ResizablePanel id="content" defaultSize="78%" minSize="50%" className="flex flex-col overflow-hidden">
-        <div className="panel-header">
-          <span className="section-title">Field Signals — Operation Epic Fury</span>
-          <span className="label ml-auto text-[var(--t4)]">PHAROS-CURATED</span>
-        </div>
-        <ScrollArea className="flex-1">
-          <div className="px-4 py-3">
-            {signalsList}
+    <div className="flex flex-col flex-1 min-h-0 min-w-0 overflow-hidden">
+      <ResizablePanelGroup orientation="horizontal" defaultLayout={defaultLayout} onLayoutChanged={onLayoutChanged} className="flex-1 min-h-0 min-w-0 w-full">
+        <ResizablePanel id="filters" defaultSize="22%" minSize="15%" maxSize="35%" className="flex flex-col overflow-hidden min-w-[180px]">
+          {filterRail}
+        </ResizablePanel>
+        <ResizableHandle />
+        <ResizablePanel id="content" defaultSize="78%" minSize="50%" className="flex flex-col overflow-hidden min-w-0">
+          <div className="panel-header">
+            <span className="section-title">Field Signals — Operation Epic Fury</span>
+            <span className="label ml-auto text-[var(--t4)]">PHAROS-CURATED</span>
           </div>
-        </ScrollArea>
-      </ResizablePanel>
-    </ResizablePanelGroup>
+          <ScrollArea className="flex-1 min-w-0">
+            <div className="px-4 py-3 min-w-0">
+              {signalsList}
+            </div>
+          </ScrollArea>
+        </ResizablePanel>
+      </ResizablePanelGroup>
+    </div>
   );
 }

--- a/src/shared/components/shared/XPostCard.tsx
+++ b/src/shared/components/shared/XPostCard.tsx
@@ -5,7 +5,7 @@ import { Tweet } from 'react-tweet';
 
 import type { XPost } from '@/types/domain';
 
-import { EmbedSkeleton,PharosView } from './PharosView';
+import { EmbedSkeleton, PharosView } from './PharosView';
 import { ACCT, SIG_BORDER, xUrl } from './x-post-constants';
 
 type Props = { post: XPost; compact?: boolean };
@@ -20,9 +20,7 @@ export function XPostCard({ post, compact }: Props) {
     <div className="card mb-2" style={{ borderLeft: `3px solid ${border}` }}>
 
       {hasEmbed ? (
-        /* ── Side-by-side: Original (left) | Pharos (right) ── */
-        <div className="grid grid-cols-[1fr_1fr] min-h-0">
-          {/* LEFT — Original embed */}
+        <div className="grid grid-cols-[1fr_1fr] min-h-0 min-w-0 overflow-hidden">
           <div
             data-theme="dark"
             className="border-r border-[var(--bd-s)] px-1 py-2 [&_>_div]:!my-0 overflow-hidden"
@@ -35,18 +33,14 @@ export function XPostCard({ post, compact }: Props) {
             </Suspense>
           </div>
 
-          {/* RIGHT — Pharos intel view */}
-          <div className="flex flex-col">
+          <div className="flex min-w-0 flex-col overflow-hidden">
             <div className="flex items-center gap-1 px-3 py-1.5">
               <span className="mono text-[8px] text-[var(--blue-l)] tracking-[0.08em]">PHAROS INTEL</span>
             </div>
             <PharosView post={post} acct={acct} postUrl={postUrl} />
           </div>
         </div>
-      ) : (
-        /* ── Standard single-column view ── */
-        <PharosView post={post} acct={acct} postUrl={postUrl} compact={compact} />
-      )}
+      ) : <PharosView post={post} acct={acct} postUrl={postUrl} compact={compact} />}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- fixes the desktop signals page blowing out horizontally when tweet embeds render side-by-side
- matches the feed page's constrained resizable layout pattern on desktop
- adds defensive `min-w-0` / `overflow-hidden` guards in the split signal card so embeds cannot force infinite width

## Why

The signals page returned its `ResizablePanelGroup` directly without the feed page's outer constrained wrapper or `w-full` on the panel group. Combined with the intrinsic width of `react-tweet` embeds inside a two-column grid, that let the content panel expand beyond the viewport on desktop.

## Changes

- `src/features/signals/components/SignalsContent.tsx`
  - wrap desktop layout in `flex flex-col flex-1 min-h-0 min-w-0 overflow-hidden`
  - add `w-full` to the `ResizablePanelGroup`
  - add `min-w-0` to the content panel and scroll content
- `src/shared/components/shared/XPostCard.tsx`
  - add `min-w-0 overflow-hidden` to the two-column grid
  - add `min-w-0 overflow-hidden` to the Pharos panel column

## Review

Checked against `CODEX.md`, `CLAUDE.md`, and `docs/CODE_REVIEW.md` after the fix and cleaned minor import/comment drift in the touched files.