### PR TITLE
docs: improve .env.local.example with Supabase pooler setup guide

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -13,8 +13,8 @@ SUPABASE_SERVICE_ROLE_KEY="sb_service_role_xxx"
 #
 # Option A — Local Docker (recommended, used by `npm run setup`)
 #   Uses the PostgreSQL container from docker-compose.yml.
-#   DATABASE_URL="postgresql://postgres:postgres@localhost:5432/pharos"
-#   DATABASE_URL_MIGRATION="postgresql://postgres:postgres@localhost:5432/pharos"
+#   DATABASE_URL="postgresql://pharos:pharos@localhost:5434/pharos"
+#   DATABASE_URL_MIGRATION="postgresql://pharos:pharos@localhost:5434/pharos"
 #
 # Option B — Supabase Cloud (no Docker required)
 #   1. Create a free project at https://supabase.com


### PR DESCRIPTION
- What
Improves .env.local.example with documentation for contributors setting up the project without Docker.

Why
Supabase direct database connections (db.*.supabase.co:5432) are now IPv6-only, which silently fails on many local networks. Contributors without Docker need to use the IPv4 connection pooler instead, but the current .env.local.example does not document this distinction or the port differences required for migrations vs runtime.

Changes
Add section headers for readability
Document Docker (Option A) vs Supabase Cloud (Option B) setup paths
Add IPv6 vs IPv4 pooler note for non-Docker environments
Explain transaction pooler (port 6543) vs session pooler (port 5432)
Add NEXT_PUBLIC_APP_URL variable
Remove unused DIRECT_URL (covered by DATABASE_URL_MIGRATION)