### PR TITLE
fix: use flexible mobile shells for zoom stability

### DIFF
--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -5,9 +5,9 @@ export default function DashboardShellLayout({ children }: { children: React.Rea
   return (
     <>
       <ViewportHeightSync />
-      <div className="flex flex-col min-h-0 overflow-hidden" style={{ height: 'var(--app-shell-height)' }}>
+      <div className="app-shell bg-[var(--bg-app)]">
         <Header />
-        <div className="flex flex-1 min-h-0 overflow-hidden pb-[var(--safe-bottom)]">
+        <div className="flex flex-1 min-h-0 pb-[var(--safe-bottom)] md:overflow-hidden">
           {children}
         </div>
       </div>

--- a/src/app/browse/layout.tsx
+++ b/src/app/browse/layout.tsx
@@ -7,8 +7,7 @@ export default function BrowseLayout({ children }: { children: React.ReactNode }
       <ViewportHeightSync />
       <div
         data-theme="auto"
-        className="flex flex-col min-h-0 overflow-hidden bg-[var(--bg-app)]"
-        style={{ height: 'var(--app-shell-height)' }}
+        className="app-shell bg-[var(--bg-app)]"
       >
         <BrowseShell>{children}</BrowseShell>
       </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,8 +6,6 @@
 
 :root {
   --app-height: 100vh;
-  --app-height-mobile: 100vh;
-  --app-shell-height: var(--app-height);
   --safe-top: env(safe-area-inset-top, 0px);
   --safe-right: env(safe-area-inset-right, 0px);
   --safe-bottom: env(safe-area-inset-bottom, 0px);
@@ -146,8 +144,6 @@
   @supports (height: 100dvh) {
     :root {
       --app-height: 100dvh;
-      --app-height-mobile: 100dvh;
-      --app-shell-height: 100dvh;
     }
   }
 
@@ -199,9 +195,29 @@
   /* Layout */
   .layout-fill { display: flex; flex: 1 1 0%; min-height: 0; overflow: hidden; }
   .layout-col  { display: flex; flex-direction: column; }
+  .app-shell {
+    display: flex;
+    min-height: 100vh;
+    flex-direction: column;
+    overflow: visible;
+  }
   .safe-px { padding-left: max(12px, var(--safe-left)); padding-right: max(12px, var(--safe-right)); }
   .safe-pt { padding-top: var(--safe-top); }
   .safe-pb { padding-bottom: var(--safe-bottom); }
+
+  @supports (min-height: 100dvh) {
+    .app-shell {
+      min-height: 100dvh;
+    }
+  }
+
+  @media (min-width: 768px) {
+    .app-shell {
+      min-height: 0;
+      height: var(--app-height);
+      overflow: hidden;
+    }
+  }
 
   /* Panel primitives */
   .panel {

--- a/src/shared/components/layout/ViewportHeightSync.tsx
+++ b/src/shared/components/layout/ViewportHeightSync.tsx
@@ -5,14 +5,9 @@ import { useEffect } from 'react';
 function updateAppHeightVar() {
   if (typeof document === 'undefined' || typeof window === 'undefined') return;
   const vv = window.visualViewport;
-  const isCoarsePointer = window.matchMedia('(pointer: coarse)').matches;
   // When pinch-zoomed (scale > 1), visualViewport.height shrinks — use innerHeight instead
   const vh = vv && vv.scale <= 1 ? vv.height : window.innerHeight;
-  const mobileVh = vv?.height ?? window.innerHeight;
-  const shellVh = isCoarsePointer ? mobileVh : vh;
   document.documentElement.style.setProperty('--app-height', `${Math.round(vh)}px`);
-  document.documentElement.style.setProperty('--app-height-mobile', `${Math.round(mobileVh)}px`);
-  document.documentElement.style.setProperty('--app-shell-height', `${Math.round(shellVh)}px`);
 }
 
 export function ViewportHeightSync() {


### PR DESCRIPTION
## Summary
- replace the mobile app shell's fixed JS-driven height with a flexible CSS shell so pinch zoom no longer creates the growing dark bottom bar
- keep the desktop dashboard and browse layouts on the existing fixed-height path while letting mobile roots avoid outer overflow clipping
- simplify `ViewportHeightSync` back to desktop-safe responsibility by only maintaining the desktop shell height token