### PR TITLE
fix: carry forward casualties and hide empty sources

### DIFF
--- a/src/app/api/v1/conflicts/[id]/days/[day]/route.ts
+++ b/src/app/api/v1/conflicts/[id]/days/[day]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from 'next/server';
 
-import { err, ok, reassembleCasualties } from '@/server/lib/api-utils';
+import { emptyCasualties, err, ok, resolveCasualties } from '@/server/lib/api-utils';
 import { prisma } from '@/server/lib/db';
 
 export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string; day: string }> }) {
@@ -16,6 +16,23 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ id:
 
   if (!snapshot) return err('NOT_FOUND', `No snapshot for ${day}`, 404);
 
+  const previousSnapshot = snapshot.casualties.length === 0
+    ? await prisma.conflictDaySnapshot.findFirst({
+      where: {
+        conflictId: id,
+        day: { lt: snapshot.day },
+        casualties: { some: {} },
+      },
+      orderBy: { day: 'desc' },
+      include: { casualties: true },
+    })
+    : null;
+
+  const casualties = resolveCasualties(
+    snapshot.casualties,
+    previousSnapshot ? resolveCasualties(previousSnapshot.casualties, emptyCasualties()) : emptyCasualties(),
+  );
+
   return ok(
     {
       day: snapshot.day.toISOString().slice(0, 10),
@@ -23,7 +40,7 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ id:
       summary: snapshot.summary,
       keyFacts: snapshot.keyFacts,
       escalation: snapshot.escalation,
-      casualties: reassembleCasualties(snapshot.casualties),
+      casualties,
       economicImpact: {
         chips: snapshot.economicChips.map(c => ({ label: c.label, val: c.val, sub: c.sub, color: c.color })),
         narrative: snapshot.economicNarrative,

--- a/src/app/api/v1/conflicts/[id]/days/route.ts
+++ b/src/app/api/v1/conflicts/[id]/days/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from 'next/server';
 
-import { err, ok, reassembleCasualties } from '@/server/lib/api-utils';
+import { emptyCasualties, err, ok, resolveCasualties } from '@/server/lib/api-utils';
 import { prisma } from '@/server/lib/db';
 
 export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
@@ -44,19 +44,24 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
 
   if (snapshots.length === 0) return err('NOT_FOUND', `No day snapshots for conflict ${id}`, 404);
 
-  const data = snapshots.map(s => ({
-    day: s.day.toISOString().slice(0, 10),
-    dayLabel: s.dayLabel,
-    summary: s.summary,
-    keyFacts: s.keyFacts,
-    escalation: s.escalation,
-    casualties: reassembleCasualties(s.casualties),
-    economicImpact: {
-      chips: s.economicChips.map(c => ({ label: c.label, val: c.val, sub: c.sub, color: c.color })),
-      narrative: s.economicNarrative,
-    },
-    scenarios: s.scenarios.map(sc => ({ label: sc.label, subtitle: sc.subtitle, color: sc.color, prob: sc.prob, body: sc.body })),
-  }));
+  let lastKnownCasualties = emptyCasualties();
+  const data = snapshots.map((snapshot) => {
+    lastKnownCasualties = resolveCasualties(snapshot.casualties, lastKnownCasualties);
+
+    return {
+      day: snapshot.day.toISOString().slice(0, 10),
+      dayLabel: snapshot.dayLabel,
+      summary: snapshot.summary,
+      keyFacts: snapshot.keyFacts,
+      escalation: snapshot.escalation,
+      casualties: lastKnownCasualties,
+      economicImpact: {
+        chips: snapshot.economicChips.map((chip) => ({ label: chip.label, val: chip.val, sub: chip.sub, color: chip.color })),
+        narrative: snapshot.economicNarrative,
+      },
+      scenarios: snapshot.scenarios.map((scenario) => ({ label: scenario.label, subtitle: scenario.subtitle, color: scenario.color, prob: scenario.prob, body: scenario.body })),
+    };
+  });
 
   return ok(data, {
     headers: { 'Cache-Control': 'public, s-maxage=30, stale-while-revalidate=120' },

--- a/src/features/browse/queries/briefs.ts
+++ b/src/features/browse/queries/briefs.ts
@@ -53,8 +53,23 @@ export const getBrief = cache(async (day: string) => {
 
   if (!row) return null;
 
+  const previousSnapshot = row.casualties.length === 0
+    ? await prisma.conflictDaySnapshot.findFirst({
+      where: {
+        conflictId: CONFLICT_ID,
+        day: { lt: date },
+        casualties: { some: {} },
+      },
+      orderBy: { day: 'desc' },
+      select: {
+        casualties: true,
+      },
+    })
+    : null;
+
   return {
     ...row,
+    casualties: row.casualties.length > 0 ? row.casualties : (previousSnapshot?.casualties ?? []),
     day: fmtDate(row.day.toISOString()),
     createdAt: row.createdAt.toISOString(),
     updatedAt: row.updatedAt.toISOString(),

--- a/src/features/events/components/EventReportContent.tsx
+++ b/src/features/events/components/EventReportContent.tsx
@@ -56,49 +56,51 @@ export function EventReportContent({ event, compact = false, pageScroll = false 
         </div>
       </div>
 
-      <div className="mb-[22px]">
-        <SectionDivider label={`SOURCES (${event.sources.length})`} />
-        <div className="flex flex-col gap-1">
-          {event.sources.map((src, i) => (
-            <div key={i} className="flex items-center gap-2.5 px-2.5 py-1.5 border border-[var(--bd)]" style={src.url ? { borderColor: 'color-mix(in srgb, var(--blue) 30%, var(--bd))' } : undefined}>
-              <span
-                className="text-[8px] font-bold px-[5px] py-px shrink-0"
-                style={{ background: TIER_C[src.tier] + '22', color: TIER_C[src.tier] }}
-              >
-                {TIER_L[src.tier]}
-              </span>
-              {src.url ? (
-                <a
-                  href={src.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-[11px] flex-1 font-medium hover:underline"
-                  style={{ color: 'var(--blue-l)', textDecoration: 'none' }}
+      {event.sources.length > 0 && (
+        <div className="mb-[22px]">
+          <SectionDivider label={`SOURCES (${event.sources.length})`} />
+          <div className="flex flex-col gap-1">
+            {event.sources.map((src, i) => (
+              <div key={i} className="flex items-center gap-2.5 px-2.5 py-1.5 border border-[var(--bd)]" style={src.url ? { borderColor: 'color-mix(in srgb, var(--blue) 30%, var(--bd))' } : undefined}>
+                <span
+                  className="text-[8px] font-bold px-[5px] py-px shrink-0"
+                  style={{ background: TIER_C[src.tier] + '22', color: TIER_C[src.tier] }}
                 >
-                  {src.name} ↗
-                </a>
-              ) : (
-                <span className="text-[11px] text-[var(--t1)] flex-1">{src.name}</span>
-              )}
-              <div className="flex items-center gap-1.5">
-                <div className="w-[50px] h-[3px] bg-[var(--bd)]">
-                  <div
-                    className="h-full"
-                    style={{
-                      width: `${src.reliability}%`,
-                      background: src.reliability > 90 ? 'var(--success)'
-                        : src.reliability > 75 ? 'var(--warning)' : 'var(--danger)',
-                    }}
-                  />
-                </div>
-                <span className="mono text-[9px] text-[var(--t3)] min-w-[26px]">
-                  {src.reliability}%
+                  {TIER_L[src.tier]}
                 </span>
+                {src.url ? (
+                  <a
+                    href={src.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-[11px] flex-1 font-medium hover:underline"
+                    style={{ color: 'var(--blue-l)', textDecoration: 'none' }}
+                  >
+                    {src.name} ↗
+                  </a>
+                ) : (
+                  <span className="text-[11px] text-[var(--t1)] flex-1">{src.name}</span>
+                )}
+                <div className="flex items-center gap-1.5">
+                  <div className="w-[50px] h-[3px] bg-[var(--bd)]">
+                    <div
+                      className="h-full"
+                      style={{
+                        width: `${src.reliability}%`,
+                        background: src.reliability > 90 ? 'var(--success)'
+                          : src.reliability > 75 ? 'var(--warning)' : 'var(--danger)',
+                      }}
+                    />
+                  </div>
+                  <span className="mono text-[9px] text-[var(--t3)] min-w-[26px]">
+                    {src.reliability}%
+                  </span>
+                </div>
               </div>
-            </div>
-          ))}
+            ))}
+          </div>
         </div>
-      </div>
+      )}
 
       {event.actorResponses.length > 0 && (
         <div className="mb-[22px]">

--- a/src/server/lib/api-utils.ts
+++ b/src/server/lib/api-utils.ts
@@ -37,6 +37,23 @@ type CasualtySummaryRow = {
   injured: number;
 };
 
+export function emptyCasualties() {
+  return {
+    us: { kia: 0, wounded: 0, civilians: 0 },
+    israel: { kia: 0, wounded: 0, civilians: 0, injured: 0 },
+    iran: { killed: 0, injured: 0 },
+    lebanon: { killed: 0, injured: 0 },
+    regional: {} as Record<string, { killed: number; injured: number }>,
+  };
+}
+
+export function resolveCasualties(
+  rows: CasualtySummaryRow[],
+  fallback = emptyCasualties(),
+) {
+  return rows.length > 0 ? reassembleCasualties(rows) : fallback;
+}
+
 /**
  * Reassemble flat CasualtySummary rows into the nested domain.ts format:
  * { us: { kia, wounded, civilians }, israel: { kia, wounded, civilians, injured },
@@ -60,6 +77,7 @@ export function reassembleCasualties(rows: CasualtySummaryRow[]) {
   }
 
   return {
+    ...emptyCasualties(),
     us: { kia: us?.killed ?? 0, wounded: us?.wounded ?? 0, civilians: us?.civilians ?? 0 },
     israel: { kia: israel?.killed ?? 0, wounded: israel?.wounded ?? 0, civilians: israel?.civilians ?? 0, injured: israel?.injured ?? 0 },
     iran: { killed: iran?.killed ?? 0, injured: iran?.injured ?? 0 },


### PR DESCRIPTION
## Summary
- carry forward the most recent casualty data when a day snapshot exists but has no casualty rows yet
- apply the same casualty fallback to browse brief detail data so today does not regress to an empty casualty table
- hide the dashboard event sources section when an event has no sources instead of rendering an empty block