### PR TITLE
fix: restore browse document scrolling

### DIFF
--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -5,7 +5,7 @@ export default function DashboardShellLayout({ children }: { children: React.Rea
   return (
     <>
       <ViewportHeightSync />
-      <div className="app-shell bg-[var(--bg-app)]">
+      <div className="dashboard-shell bg-[var(--bg-app)]">
         <Header />
         <div className="flex flex-1 min-h-0 pb-[var(--safe-bottom)] md:overflow-hidden">
           {children}

--- a/src/app/browse/layout.tsx
+++ b/src/app/browse/layout.tsx
@@ -5,10 +5,7 @@ export default function BrowseLayout({ children }: { children: React.ReactNode }
   return (
     <>
       <ViewportHeightSync />
-      <div
-        data-theme="auto"
-        className="app-shell bg-[var(--bg-app)]"
-      >
+      <div data-theme="auto" className="browse-shell bg-[var(--bg-app)]">
         <BrowseShell>{children}</BrowseShell>
       </div>
     </>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -195,7 +195,13 @@
   /* Layout */
   .layout-fill { display: flex; flex: 1 1 0%; min-height: 0; overflow: hidden; }
   .layout-col  { display: flex; flex-direction: column; }
-  .app-shell {
+  .dashboard-shell {
+    display: flex;
+    min-height: 100vh;
+    flex-direction: column;
+    overflow: visible;
+  }
+  .browse-shell {
     display: flex;
     min-height: 100vh;
     flex-direction: column;
@@ -206,13 +212,17 @@
   .safe-pb { padding-bottom: var(--safe-bottom); }
 
   @supports (min-height: 100dvh) {
-    .app-shell {
+    .dashboard-shell {
+      min-height: 100dvh;
+    }
+
+    .browse-shell {
       min-height: 100dvh;
     }
   }
 
   @media (min-width: 768px) {
-    .app-shell {
+    .dashboard-shell {
       min-height: 0;
       height: var(--app-height);
       overflow: hidden;

--- a/src/features/browse/components/layout/BrowseShell.tsx
+++ b/src/features/browse/components/layout/BrowseShell.tsx
@@ -59,7 +59,7 @@ export function BrowseShell({ children }: Props) {
     <>
       <BrowseNav hamburgerSlot={hamburgerButton} />
 
-      <div className="flex flex-1 min-h-0 overflow-hidden">
+      <div className="flex flex-1 min-h-0">
         {showDesktopSidebar && <BrowseSidebar />}
 
         {showMobileSheet && (
@@ -76,7 +76,7 @@ export function BrowseShell({ children }: Props) {
           </Sheet>
         )}
 
-        <main className="flex-1 min-h-0 overflow-y-auto">
+        <main className="flex-1 min-h-0">
           {isDetailPage && <BrowseArticleBanner />}
           {children}
           {isLanding && <BrowseFooter />}


### PR DESCRIPTION
## Summary
- restore browse routes to normal document scrolling instead of treating them like a fixed-height app shell
- keep the dashboard shell behavior separate so the mobile zoom fix remains intact without leaking nested scroll constraints into browse
- remove the brittle browse scroll-lock approach and let browse content pages, including events, scroll naturally again