### PR TITLE
fix: repair CI pipeline — update Prisma drift check and backfill missing migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,7 @@ jobs:
           DATABASE_URL: "postgresql://pharos:pharos@localhost:5432/pharos?schema=public"
 
       - name: Check for schema drift
-        run: npx prisma migrate diff --from-migrations ./prisma/migrations --to-schema-datamodel ./prisma/schema.prisma --exit-code
+        run: npx prisma migrate diff --from-migrations ./prisma/migrations --to-schema ./prisma/schema.prisma --exit-code
         env:
           DATABASE_URL: "postgresql://pharos:pharos@localhost:5432/pharos?schema=public"
+          SHADOW_DATABASE_URL: "postgresql://pharos:pharos@localhost:5432/postgres?schema=public"

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -11,5 +11,6 @@ export default defineConfig({
     // Allow prisma generate to succeed without a DATABASE_URL (e.g. in CI build steps).
     // Migrations and runtime still require a real connection string.
     url: process.env.DATABASE_URL ?? "postgresql://placeholder:placeholder@localhost:5432/placeholder",
+    shadowDatabaseUrl: process.env.SHADOW_DATABASE_URL,
   },
 });

--- a/prisma/migrations/20260313175805_actor_map_fields_and_xpost_verification/migration.sql
+++ b/prisma/migrations/20260313175805_actor_map_fields_and_xpost_verification/migration.sql
@@ -1,0 +1,32 @@
+-- CreateEnum
+CREATE TYPE "PostType" AS ENUM ('XPOST', 'NEWS_ARTICLE', 'OFFICIAL_STATEMENT', 'PRESS_RELEASE', 'ANALYSIS');
+
+-- CreateEnum
+CREATE TYPE "Affiliation" AS ENUM ('FRIENDLY', 'HOSTILE', 'NEUTRAL');
+
+-- CreateEnum
+CREATE TYPE "VerificationStatus" AS ENUM ('UNVERIFIED', 'VERIFIED', 'FAILED', 'PARTIAL', 'SKIPPED');
+
+-- AlterTable
+ALTER TABLE "Actor" ADD COLUMN     "affiliation" "Affiliation",
+ADD COLUMN     "colorRgb" INTEGER[],
+ADD COLUMN     "cssVar" TEXT,
+ADD COLUMN     "mapGroup" TEXT,
+ADD COLUMN     "mapKey" TEXT;
+
+-- AlterTable
+ALTER TABLE "XPost" ADD COLUMN     "postType" "PostType" NOT NULL DEFAULT 'XPOST',
+ADD COLUMN     "tweetId" TEXT,
+ADD COLUMN     "verificationResult" JSONB,
+ADD COLUMN     "verificationStatus" "VerificationStatus" NOT NULL DEFAULT 'UNVERIFIED',
+ADD COLUMN     "verifiedAt" TIMESTAMP(3),
+ADD COLUMN     "xaiCitations" TEXT[];
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Actor_mapKey_key" ON "Actor"("mapKey");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "XPost_tweetId_key" ON "XPost"("tweetId");
+
+-- CreateIndex
+CREATE INDEX "XPost_verificationStatus_idx" ON "XPost"("verificationStatus");

--- a/src/features/economics/components/EconomicsContent.tsx
+++ b/src/features/economics/components/EconomicsContent.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo,useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import Link from 'next/link';
 
@@ -14,6 +14,7 @@ import { useEconomicIndexes, useMarketData } from '@/features/economics/queries'
 
 import { useIsLandscapePhone } from '@/shared/hooks/use-is-landscape-phone';
 import { useLandscapeScrollEmitter } from '@/shared/hooks/use-landscape-scroll-emitter';
+import { useNow } from '@/shared/hooks/use-now';
 
 import { ECON_CATEGORIES } from '@/data/economic-indexes';
 import type { EconCategory, EconomicIndex, MarketResult } from '@/types/domain';
@@ -39,6 +40,7 @@ export function EconomicsContent() {
   const [tierFilter, setTierFilter] = useState(0); // 0 = all
   const [catFilter, setCatFilter] = useState<EconCategory | 'ALL'>('ALL');
   const [focusedId, setFocusedId] = useState<string | null>(null);
+  const now = useNow();
   const isLandscapePhone = useIsLandscapePhone();
   const onLandscapeScroll = useLandscapeScrollEmitter(isLandscapePhone);
 
@@ -64,7 +66,7 @@ export function EconomicsContent() {
     return true;
   });
 
-  const timeSince = lastRefresh > 0 ? `${Math.floor((Date.now() - lastRefresh) / 1000)}s ago` : 'loading…';
+  const timeSince = lastRefresh > 0 ? `${Math.floor((now - lastRefresh) / 1000)}s ago` : 'loading…';
 
   return (
     <div

--- a/src/features/predictions/components/FocusedMarket.tsx
+++ b/src/features/predictions/components/FocusedMarket.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback,useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
 
@@ -29,6 +29,7 @@ export function FocusedMarket({ market, group, onClose }: Props) {
   const [open,         setOpen]         = useState(false);
   const [rangeIdx,     setRangeIdx]     = useState(1); // default 7D
   const [crosshairPct, setCrosshairPct] = useState<number | null>(null);
+  const [nowMs]                         = useState(() => Date.now());
 
   const range = RANGES[rangeIdx].key;
   const { data: historyData, isLoading: chartLoading } = usePredictionHistory(market.yesTokenId ?? '', range);
@@ -39,7 +40,7 @@ export function FocusedMarket({ market, group, onClose }: Props) {
   const status = statusLabel(market);
 
   const daysLeft = market.endDate
-    ? Math.max(0, Math.floor((new Date(market.endDate).getTime() - Date.now()) / 86_400_000))
+    ? Math.max(0, Math.floor((new Date(market.endDate).getTime() - nowMs) / 86_400_000))
     : null;
 
   useEffect(() => {

--- a/src/features/predictions/components/PredictionsDataContent.tsx
+++ b/src/features/predictions/components/PredictionsDataContent.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo,useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import Link from 'next/link';
 
@@ -13,6 +13,7 @@ import { usePredictionMarkets } from '@/features/predictions/queries';
 
 import { useIsLandscapePhone } from '@/shared/hooks/use-is-landscape-phone';
 import { useLandscapeScrollEmitter } from '@/shared/hooks/use-landscape-scroll-emitter';
+import { useNow } from '@/shared/hooks/use-now';
 
 import { assignGroup,MARKET_GROUPS, UNCATEGORIZED_GROUP } from '@/data/prediction-groups';
 
@@ -37,6 +38,7 @@ export function PredictionsDataContent() {
   const [liveOnly,     setLiveOnly]     = useState(true);
   const [groupFilter,  setGroupFilter]  = useState<string>('ALL');
   const [focusedId,    setFocusedId]    = useState<string | null>(null);
+  const now = useNow();
   const isLandscapePhone = useIsLandscapePhone();
   const onLandscapeScroll = useLandscapeScrollEmitter(isLandscapePhone);
 
@@ -71,7 +73,7 @@ export function PredictionsDataContent() {
   const totalVol   = markets.reduce((s, m) => s + m.volume, 0);
   const totalVol24 = markets.reduce((s, m) => s + m.volume24hr, 0);
   const liveCount  = markets.filter(m => m.active && !m.closed).length;
-  const timeSince  = fetchedAt ? `${Math.floor((Date.now() - fetchedAt) / 1000)}s ago` : 'loading…';
+  const timeSince = fetchedAt ? `${Math.floor((now - fetchedAt) / 1000)}s ago` : 'loading…';
 
   const focusedMarket = focusedId ? markets.find(m => m.id === focusedId) ?? null : null;
   const focusedGroup  = focusedMarket ? assignGroup(focusedMarket.title) : null;


### PR DESCRIPTION
## Summary

- Updated Prisma CLI flag `--to-schema-datamodel` → `--to-schema` in CI drift check (removed in Prisma 7.x)
- Added `shadowDatabaseUrl` to `prisma.config.ts` and `SHADOW_DATABASE_URL` env in CI workflow (required by Prisma 7.x for migration diffing)
- Backfilled missing migration `20260313175805_actor_map_fields_and_xpost_verification` to align migration history with `schema.prisma` — these changes already exist in production but had no migration file, causing the drift check to fail on fresh DBs
- Fixed `react-hooks/purity` lint errors in `EconomicsContent`, `PredictionsDataContent`, and `FocusedMarket` by using existing `useNow()` hook and `useState(() => Date.now())` patterns already established in the codebase

## What was failing

1. **Prisma drift check** — used a removed CLI flag, then once fixed, detected schema drift because migration history was incomplete
2. **ESLint** — `Date.now()` called directly during render in 3 components violated `react-hooks/purity`

## Migration note

The new migration records schema changes (3 enums, 5 Actor columns, 6 XPost columns, 3 indexes) that were already applied to production via `db push`. Existing clones just need to run `prisma migrate deploy` to pick up the new migration file.

## Verification

- `npm run lint` — 0 errors (18 pre-existing warnings)
- `npx tsc --noEmit` — clean
- `npm run build` — clean
- `prisma migrate diff --exit-code` — `No difference detected`