### PR TITLE
fix: protect OSINT queue dashboard

### DIFF
--- a/osint/.env.example
+++ b/osint/.env.example
@@ -24,3 +24,11 @@ CLOUDFLARE_API_TOKEN=
 
 # Server
 PORT=4000
+OSINT_CORS_ORIGINS=http://localhost:3000,http://localhost:4000,http://127.0.0.1:3000,http://127.0.0.1:4000
+
+# Optional Bull Board job dashboard.
+# Keep disabled for public deployments unless protected by these credentials
+# and TLS or an external private network boundary.
+OSINT_QUEUE_DASHBOARD_ENABLED=false
+OSINT_QUEUE_DASHBOARD_USERNAME=
+OSINT_QUEUE_DASHBOARD_PASSWORD=

--- a/osint/README.md
+++ b/osint/README.md
@@ -60,7 +60,7 @@ npm run dev
 
 | URL | What |
 |-----|------|
-| `localhost:4000/admin/queues` | Bull Board — job dashboard (logs, progress, results) |
+| `localhost:4000/admin/queues` | Optional Bull Board job dashboard (disabled by default; enable with `OSINT_QUEUE_DASHBOARD_ENABLED=true` and credentials) |
 | `localhost:4000/api/health` | Service health (DB, Redis, streams, all sources) |
 | `localhost:4000/api/sources` | Per-source sync metadata |
 | `localhost:4000/api/providers/{provider}/features` | Provider-specific derived features |
@@ -78,6 +78,22 @@ npm run dev
 | Prisma | ORM — `osint` schema in shared PostgreSQL |
 | MinIO (local) / R2 (prod) | S3-compatible object storage for raw files |
 | ws | WebSocket client for persistent streams |
+
+## Admin surfaces
+
+Bull Board exposes queue names, job payloads, logs, failures, and retry controls. It is disabled by default and should not be exposed publicly.
+
+To enable it for local or private operator use:
+
+```bash
+OSINT_QUEUE_DASHBOARD_ENABLED=true
+OSINT_QUEUE_DASHBOARD_USERNAME=admin
+OSINT_QUEUE_DASHBOARD_PASSWORD=change-this
+```
+
+HTTP Basic auth does not protect credentials on plaintext connections. If this dashboard is reachable beyond localhost, terminate TLS in front of it or keep it behind a private network boundary. The service does not provide brute-force protection for this operator UI.
+
+The OSINT API also restricts browser CORS to `OSINT_CORS_ORIGINS`, a comma-separated list of trusted frontend origins.
 
 ## Directory structure
 

--- a/osint/docs/JOBS.md
+++ b/osint/docs/JOBS.md
@@ -8,7 +8,7 @@ How the ingestion pipeline works and how to write jobs correctly.
 |-----------|---------|
 | BullMQ | Job queue — scheduling, retries, concurrency |
 | Redis | BullMQ backend (port 6382 locally) |
-| Bull Board | Web UI at `/admin/queues` — logs, progress, results |
+| Bull Board | Optional protected web UI at `/admin/queues` — logs, progress, results |
 
 ## Writing a job processor
 
@@ -181,7 +181,15 @@ This makes the health API unambiguous — you can tell if the last run was small
 
 ## Bull Board
 
-Available at `http://localhost:4000/admin/queues`. Shows:
+Disabled by default because it exposes queue internals and retry controls. Enable it only for local or private operator access:
+
+```bash
+OSINT_QUEUE_DASHBOARD_ENABLED=true
+OSINT_QUEUE_DASHBOARD_USERNAME=admin
+OSINT_QUEUE_DASHBOARD_PASSWORD=change-this
+```
+
+When enabled, it is available at `http://localhost:4000/admin/queues` and shows:
 
 - **Job list** — waiting, active, completed, failed, delayed
 - **Logs tab** — all `job.log()` entries with timestamps

--- a/osint/src/config.ts
+++ b/osint/src/config.ts
@@ -1,6 +1,22 @@
 export const config = {
   port: parseInt(process.env.PORT || '4000', 10),
 
+  cors: {
+    allowedOrigins: (
+      process.env.OSINT_CORS_ORIGINS ||
+      'http://localhost:3000,http://localhost:4000,http://127.0.0.1:3000,http://127.0.0.1:4000'
+    )
+      .split(',')
+      .map((origin) => origin.trim())
+      .filter(Boolean),
+  },
+
+  queueDashboard: {
+    enabled: process.env.OSINT_QUEUE_DASHBOARD_ENABLED === 'true',
+    username: process.env.OSINT_QUEUE_DASHBOARD_USERNAME || '',
+    password: process.env.OSINT_QUEUE_DASHBOARD_PASSWORD || '',
+  },
+
   db: {
     url: process.env.DATABASE_URL || 'postgresql://pharos:pharos@localhost:5434/pharos',
   },

--- a/osint/src/server.ts
+++ b/osint/src/server.ts
@@ -1,5 +1,8 @@
 import 'dotenv/config';
+import { timingSafeEqual } from 'crypto';
+
 import express from 'express';
+import type { RequestHandler } from 'express';
 import { createBullBoard } from '@bull-board/api';
 import { BullMQAdapter } from '@bull-board/api/bullMQAdapter';
 import { ExpressAdapter } from '@bull-board/express';
@@ -22,6 +25,48 @@ import sourcesRouter from './api/sources.js';
 const app = express();
 app.use(express.json());
 
+function safeEqual(actual: string, expected: string): boolean {
+  const actualBuffer = Buffer.from(actual);
+  const expectedBuffer = Buffer.from(expected);
+  return actualBuffer.length === expectedBuffer.length && timingSafeEqual(actualBuffer, expectedBuffer);
+}
+
+function basicAuthMatches(header: string | undefined): boolean {
+  if (!header) return false;
+
+  const [scheme, encoded] = header.split(' ', 2);
+  if (!scheme || !encoded || scheme.toLowerCase() !== 'basic') return false;
+
+  const decoded = Buffer.from(encoded, 'base64').toString('utf8');
+  const separator = decoded.indexOf(':');
+  if (separator === -1) return false;
+
+  const username = decoded.slice(0, separator);
+  const password = decoded.slice(separator + 1);
+  return (
+    safeEqual(username, config.queueDashboard.username) &&
+    safeEqual(password, config.queueDashboard.password)
+  );
+}
+
+function requireQueueDashboardAuth(): RequestHandler {
+  if (!config.queueDashboard.username || !config.queueDashboard.password) {
+    throw new Error(
+      'OSINT queue dashboard is enabled, but OSINT_QUEUE_DASHBOARD_USERNAME or OSINT_QUEUE_DASHBOARD_PASSWORD is missing',
+    );
+  }
+
+  return (req, res, next) => {
+    if (basicAuthMatches(req.header('authorization'))) {
+      next();
+      return;
+    }
+
+    res.setHeader('WWW-Authenticate', 'Basic realm="Pharos OSINT queues"');
+    res.status(401).send('Authentication required');
+  };
+}
+
 // Request timing
 app.use((req, res, next) => {
   const start = performance.now();
@@ -35,22 +80,34 @@ app.use((req, res, next) => {
   next();
 });
 
-// CORS for local playground dev
-app.use((_req, res, next) => {
-  res.header('Access-Control-Allow-Origin', '*');
+// CORS for local playground dev and explicitly configured frontends.
+app.use((req, res, next) => {
+  const origin = req.header('origin');
+  if (origin) {
+    res.header('Vary', 'Origin');
+    if (config.cors.allowedOrigins.includes(origin)) {
+      res.header('Access-Control-Allow-Origin', origin);
+    }
+  }
   res.header('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
-  res.header('Access-Control-Allow-Headers', 'Content-Type');
+  res.header('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+  if (req.method === 'OPTIONS') {
+    res.sendStatus(204);
+    return;
+  }
   next();
 });
 
-// Bull Board — job dashboard
-const serverAdapter = new ExpressAdapter();
-serverAdapter.setBasePath('/admin/queues');
-createBullBoard({
-  queues: [new BullMQAdapter(ingestQueue)],
-  serverAdapter,
-});
-app.use('/admin/queues', serverAdapter.getRouter());
+// Bull Board — job dashboard. Disabled by default because it exposes job state and controls.
+if (config.queueDashboard.enabled) {
+  const serverAdapter = new ExpressAdapter();
+  serverAdapter.setBasePath('/admin/queues');
+  createBullBoard({
+    queues: [new BullMQAdapter(ingestQueue)],
+    serverAdapter,
+  });
+  app.use('/admin/queues', requireQueueDashboardAuth(), serverAdapter.getRouter());
+}
 
 // Routes
 app.use(healthRouter);
@@ -89,7 +146,11 @@ async function start() {
 
   app.listen(config.port, () => {
     console.log(`OSINT service listening on :${config.port}`);
-    console.log(`Job dashboard: http://localhost:${config.port}/admin/queues`);
+    if (config.queueDashboard.enabled) {
+      console.log(`Job dashboard: http://localhost:${config.port}/admin/queues`);
+    } else {
+      console.log('Job dashboard disabled; set OSINT_QUEUE_DASHBOARD_ENABLED=true to enable it');
+    }
   });
 }
 


### PR DESCRIPTION
## Summary
- disable the OSINT Bull Board queue dashboard by default
- require HTTP Basic auth from env when the dashboard is explicitly enabled
- replace wildcard OSINT CORS with an allowed-origin list
- document the dashboard controls in the OSINT README, env example, and jobs guide

## Verification
- npm ci --include=dev
- npm run db:generate
- npm run build *(fails on existing unrelated OSINT type gaps: missing GeoJSON namespace and ws declarations; touched server/config files are not in the error set)*
- npm run build 2>&1 | rg 'src/(server|config)\.ts' || true
- git diff --check

Closes #87